### PR TITLE
Update README.md: dependencies do not have to be installed explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ The LLfreq package provides Laplace approximation Bayesian Gaussian Process regr
 ## Installation
 
 ```r
-install.packages("mvtnorm")
 install.packages("devtools")
 library(devtools)
 install_github("Tan-Furukawa/LLfreq")


### PR DESCRIPTION
Dependencies do not have to be installed explicitly as long as they are specified in the `Imports` section of `DESCRIPTION` file
https://github.com/Tan-Furukawa/LLfreq/blob/6f944ec2e8d5cf183ede4761020359eb1dc2f49b/DESCRIPTION#L16